### PR TITLE
Position cursor on last column when reaching the last line

### DIFF
--- a/plugin/paragraphmotion.vim
+++ b/plugin/paragraphmotion.vim
@@ -37,7 +37,6 @@ function! ParagraphMove(delta, visual, count)
         endif
         let i += 1
     endwhile
-    normal |
 endfunction
 
 nnoremap <unique> <silent> } :<C-U>call ParagraphMove( 1, 0, v:count)<CR>


### PR DESCRIPTION
Problem: a forward paragraph motion that ends on the last line of the
buffer will cause the cursor to be positioned on the first column. This
differs from Vim's behavior. In Vim, the cursor would be positioned on
the last column.