### PR TITLE
Use :normal! instead of :normal

### DIFF
--- a/plugin/paragraphmotion.vim
+++ b/plugin/paragraphmotion.vim
@@ -6,9 +6,9 @@ endif
 let g:loaded_paragraphmotion=1
 
 function! ParagraphMove(delta, visual, count)
-    normal m'
+    normal! m'
     if a:visual
-        normal gv
+        normal! gv
     endif
 
     let i = 0


### PR DESCRIPTION
The behavior of `normal` depends on the user's key mappings. Use `normal!` instead.

Silly example: the plugin would break if the user has mapped `m'`to `ZQ` (`:map m' ZQ`).