### PR TITLE
Fix forward paragraph motion when current line has length 1

### DIFF
--- a/plugin/paragraphmotion.vim
+++ b/plugin/paragraphmotion.vim
@@ -23,7 +23,7 @@ function! s:ParagraphMove(delta, visual, count)
         while i < a:count
             " First empty or whitespace-only line below a line that contains
             " non-whitespace characters.
-            if search('\m[^[:space:]]', 'W') == 0 || search('\m^[[:space:]]*$', 'W') == 0
+            if search('\m[^[:space:]]', 'Wc') == 0 || search('\m^[[:space:]]*$', 'W') == 0
                 call search('\m\%$', 'W')
                 return
             endif


### PR DESCRIPTION
Suppose there are three lines in a file. 

```
A
 
 
```

The first line has one character — a non-whitespace character. The other two lines are blank. If the user positions the cursor on the first line and presses <kbd>}</kbd>, the cursor will move to the third line. That is wrong. The cursor should move to the second line.